### PR TITLE
docs: virtual declaration for `uno.css` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ export default {
 `main.ts`
 
 ```ts
-import 'uno.css'
+import 'virtual:uno.css'
 ```
 
 <br></details>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -98,7 +98,7 @@ export default {
 `main.ts`
 
 ```ts
-import 'uno.css'
+import 'virtual:uno.css'
 ```
 
 <br></details>


### PR DESCRIPTION
在vite项目中，需要使用'virtual:'明确声明使用的是虚拟模块，否则会找不到相关依赖