### PR TITLE
fix(preset-rem-rpx): unit conversion in the CSS function

### DIFF
--- a/packages/preset-rem-rpx/src/index.ts
+++ b/packages/preset-rem-rpx/src/index.ts
@@ -1,7 +1,7 @@
 import type { Preset } from 'unocss'
 
-const remRE = /^-?[\.\d]+rem$/
-const rpxRE = /^-?[\.\d]+rpx$/
+const remRE = /(-?[\.\d]+)rem/g
+const rpxRE = /(-?[\.\d]+)rpx/g
 
 export interface RemRpxOptions {
   /**
@@ -44,11 +44,11 @@ export function presetRemRpx(options: RemRpxOptions = {}): Preset {
 }
 
 function rem2rpx(value: string, baseFontSize: number, screenWidth: number) {
-  return `${+value.slice(0, -3) * baseFontSize * (750 / screenWidth)}rpx`
+  return value.replace(remRE, (_, p1) => `${p1 * baseFontSize * (750 / screenWidth)}rpx`)
 }
 
 function rpx2rem(value: string, baseFontSize: number, screenWidth: number) {
-  return `${+value.slice(0, -3) / (750 / screenWidth) / baseFontSize}rem`
+  return value.replace(rpxRE, (_, p1) => `${p1 / (750 / screenWidth) / baseFontSize}rem`)
 }
 
 export default presetRemRpx

--- a/test/preset-rem-rpx.test.ts
+++ b/test/preset-rem-rpx.test.ts
@@ -1,12 +1,12 @@
 import { createGenerator } from '@unocss/core'
 import { describe, expect, it } from 'vitest'
 import presetRemRpx from '@unocss-applet/preset-rem-rpx'
-import presetMini from '@unocss/preset-mini'
+import presetUno from '@unocss/preset-uno'
 
 describe('rem-rpx', () => {
   const unoRemToRpx = createGenerator({
     presets: [
-      presetMini(),
+      presetUno(),
       presetRemRpx({
         baseFontSize: 16,
         screenWidth: 375,
@@ -17,7 +17,7 @@ describe('rem-rpx', () => {
 
   const unoRpxToRem = createGenerator({
     presets: [
-      presetMini(),
+      presetUno(),
       presetRemRpx({
         baseFontSize: 16,
         screenWidth: 375,
@@ -28,28 +28,30 @@ describe('rem-rpx', () => {
 
   it('should rem to rpx', async () => {
     expect((await unoRemToRpx.generate(
-      new Set(['m4', 'mx2', '-p2', 'gap2']),
+      new Set(['m4', 'mx2', '-p2', 'gap2', 'space-x-4']),
       { preflights: false },
     )).css)
       .toMatchInlineSnapshot(`
         "/* layer: default */
-        .-p2{padding:-16rpx;}
         .m4{margin:32rpx;}
         .mx2{margin-left:16rpx;margin-right:16rpx;}
-        .gap2{gap:16rpx;}"
+        .gap2{gap:16rpx;}
+        .space-x-4>:not([hidden])~:not([hidden]){--un-space-x-reverse:0;margin-left:calc(32rpx * calc(1 - var(--un-space-x-reverse)));margin-right:calc(32rpx * var(--un-space-x-reverse));}
+        .-p2{padding:-16rpx;}"
       `)
   })
 
   it('should rpx to rem', async () => {
     expect((await unoRpxToRem.generate(
-      new Set(['m-32rpx', 'mx-16rpx', '-p-2prx', 'gap-2rpx']),
+      new Set(['m-32rpx', 'mx-16rpx', '-p-2prx', 'gap-2rpx', 'space-x-32rpx']),
       { preflights: false },
     )).css)
       .toMatchInlineSnapshot(`
         "/* layer: default */
         .m-32rpx{margin:1rem;}
         .mx-16rpx{margin-left:0.5rem;margin-right:0.5rem;}
-        .gap-2rpx{gap:0.0625rem;}"
+        .gap-2rpx{gap:0.0625rem;}
+        .space-x-32rpx>:not([hidden])~:not([hidden]){--un-space-x-reverse:0;margin-left:calc(1rem * calc(1 - var(--un-space-x-reverse)));margin-right:calc(1rem * var(--un-space-x-reverse));}"
       `)
   })
 })


### PR DESCRIPTION
preset-rem-rpx cannot correctly convert values containing CSS functions, such as 'space-x'.