### PR TITLE
Fix incorrect space encoding

### DIFF
--- a/packages/preset-applet/src/index.ts
+++ b/packages/preset-applet/src/index.ts
@@ -2,7 +2,7 @@ import type { Preset } from 'unocss'
 import { presetUno } from 'unocss'
 import type { Theme } from '@unocss/preset-uno'
 import { normalizePreflights } from '@unocss/preset-mini'
-import { UNSUPPORTED_CHARS, encodeNonLatin } from '../../shared/src'
+import { UNSUPPORTED_CHARS, encodeNonSpaceLatin } from '../../shared/src'
 import { appletPreflights } from './preflights'
 import type { PresetAppletOptions } from './types'
 import { variantSpaceAndDivide } from './variants'
@@ -40,7 +40,7 @@ export function presetApplet(options: PresetAppletOptions = {}): Preset<Theme> {
       (util) => {
         if (util.selector) {
           util.selector = unoCSSToAppletProcess(util.selector)
-          util.selector = encodeNonLatin(util.selector)
+          util.selector = encodeNonSpaceLatin(util.selector)
         }
         return util
       },

--- a/packages/preset-applet/src/transformers.ts
+++ b/packages/preset-applet/src/transformers.ts
@@ -1,5 +1,5 @@
 import type { SourceCodeTransformer } from 'unocss'
-import { UNSUPPORTED_CHARS, encodeNonLatin } from '../../shared/src'
+import { UNSUPPORTED_CHARS, encodeNonSpaceLatin } from '../../shared/src'
 
 export interface TransformerAppletOptions {
   /**
@@ -36,7 +36,7 @@ export function transformerApplet(options: TransformerAppletOptions = {}): Sourc
         .filter(i => !i.includes('='))
       for (const replace of replacements) {
         let replaced = replace.replace(charReplaceReg, '_a_')
-        replaced = encodeNonLatin(replaced)
+        replaced = encodeNonSpaceLatin(replaced)
 
         // delete all - prefix
         while (replaced.startsWith('-'))

--- a/packages/shared/src/helper.ts
+++ b/packages/shared/src/helper.ts
@@ -1,7 +1,7 @@
-// 编码非Latin字符
+// 编码空格及Latin字符以外的字符
 // 例如：'你好' => '203202'
-export function encodeNonLatin(str: string) {
-  const regex = /[^A-Za-z0-9!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~\\]+/g
+export function encodeNonSpaceLatin(str: string) {
+  const regex = /[^A-Za-z0-9!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~\\ ]+/g
 
   if (!regex.test(str))
     return str

--- a/test/__snapshots__/preset-applet.test.ts.snap
+++ b/test/__snapshots__/preset-applet.test.ts.snap
@@ -107,10 +107,11 @@ exports[`preset-applet > targets 1`] = `
 
 exports[`preset-applet > targets2 1`] = `
 "/* layer: default */
+._a__a___a_nut-button_a__a_text-lg .nut-button{font-size:1.125rem;line-height:1.75rem;}
 .cls.multi,
 section{--un-text-opacity:1;color:rgba(156,163,175,var(--un-text-opacity));}
 @media (prefers-color-scheme: dark){
-.body32main{--un-bg-opacity:1;background-color:rgba(255,255,255,var(--un-bg-opacity));}
+.body main{--un-bg-opacity:1;background-color:rgba(255,255,255,var(--un-bg-opacity));}
 }
 @media (min-width: 768px){
 aside{--un-shadow:var(--un-shadow-inset) 0 20px 25px -5px var(--un-shadow-color, rgba(0,0,0,0.1)),var(--un-shadow-inset) 0 8px 10px -6px var(--un-shadow-color, rgba(0,0,0,0.1));box-shadow:var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow);}

--- a/test/preset-applet.test.ts
+++ b/test/preset-applet.test.ts
@@ -88,6 +88,7 @@ const targets2 = [
   'selector-[.cls.multi]:c-gray-400',
   'md:selector-[aside]:shadow-xl',
   'dark:selector-[.body_main]:bg-white',
+  '[&_.nut-button]:text-lg',
 ]
 
 const nonTargets = [

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,15 +1,15 @@
 import { expect, it } from 'vitest'
-import { encodeNonLatin } from '../packages/shared/src'
+import { encodeNonSpaceLatin } from '../packages/shared/src'
 
-it('encodeNonLatin', () => {
-  expect(encodeNonLatin('你好，谢谢，再见(Hello, thank you, goodbye)'))
-    .toMatchInlineSnapshot('"2032022909652923587435874652922087735265(Hello,32thank32you,32goodbye)"')
-  expect(encodeNonLatin('こんにちは、ありがとう、さようなら (Hello, thank you, goodbye)'))
-    .toMatchInlineSnapshot('"123711243512395123851239912289123541242612364123921235812289123731242412358123941242532(Hello,32thank32you,32goodbye)"')
-  expect(encodeNonLatin('안녕하세요、감사합니다、안녕히 가세요 (Hello, thank you, goodbye)'))
-    .toMatchInlineSnapshot('"5050445397546164946450836122894404849324546334576845796122895050445397551763244032494645083632(Hello,32thank32you,32goodbye)"')
-  expect(encodeNonLatin('Lorem ipsum dolor sit amet, consectetur adipiscing elit. (Latin text used as a placeholder)'))
-    .toMatchInlineSnapshot('"Lorem32ipsum32dolor32sit32amet,32consectetur32adipiscing32elit.32(Latin32text32used32as32a32placeholder)"')
-  expect(encodeNonLatin('Здравствуйте、Спасибо、До свидания (Hello, thank you, goodbye)'))
-    .toMatchInlineSnapshot('"1047107610881072107410891090107410911081109010771228910571087107210891080107310861228910441086321089107410801076107210851080110332(Hello,32thank32you,32goodbye)"')
+it('encodeNonSpaceLatin', () => {
+  expect(encodeNonSpaceLatin('你好，谢谢，再见(Hello, thank you, goodbye)'))
+    .toMatchInlineSnapshot('"2032022909652923587435874652922087735265(Hello, thank you, goodbye)"')
+  expect(encodeNonSpaceLatin('こんにちは、ありがとう、さようなら (Hello, thank you, goodbye)'))
+    .toMatchInlineSnapshot('"1237112435123951238512399122891235412426123641239212358122891237312424123581239412425 (Hello, thank you, goodbye)"')
+  expect(encodeNonSpaceLatin('안녕하세요、감사합니다、안녕히 가세요 (Hello, thank you, goodbye)'))
+    .toMatchInlineSnapshot('"505044539754616494645083612289440484932454633457684579612289505044539755176 440324946450836 (Hello, thank you, goodbye)"')
+  expect(encodeNonSpaceLatin('Lorem ipsum dolor sit amet, consectetur adipiscing elit. (Latin text used as a placeholder)'))
+    .toMatchInlineSnapshot('"Lorem ipsum dolor sit amet, consectetur adipiscing elit. (Latin text used as a placeholder)"')
+  expect(encodeNonSpaceLatin('Здравствуйте、Спасибо、До свидания (Hello, thank you, goodbye)'))
+    .toMatchInlineSnapshot('"1047107610881072107410891090107410911081109010771228910571087107210891080107310861228910441086 10891074108010761072108510801103 (Hello, thank you, goodbye)"')
 })


### PR DESCRIPTION
当前在arbitrary variants模式中使用后代选择器“空格”会被编码成“32”，这导致了后代选择器无法生效，我认为不应该对“空格”编码，因为在unocss中已经使用了“_”来代替“空格”，例如：before:content-['测_试空_格']。