### PR TITLE
fix(preset-applet): incorrect preflight default value

### DIFF
--- a/packages/preset-applet/src/index.ts
+++ b/packages/preset-applet/src/index.ts
@@ -11,6 +11,7 @@ import { transformerApplet } from './transformers'
 export * from './types'
 
 export function presetApplet(options: PresetAppletOptions = {}): Preset<Theme> {
+  options.preflight = options.preflight ?? true
   options.variablePrefix = options.variablePrefix ?? 'un-'
 
   const _UNSUPPORTED_CHARS = [...UNSUPPORTED_CHARS, ...(options.unsupportedChars ?? [])]


### PR DESCRIPTION
当前在preset-applet中，preflight的默认值为falsy，这不符合@default注释，且preset-applet的preflights选项没有正确执行，会导致transform类样式无法生效，如：rotate-45。