### PR TITLE
fix(preset-applet): incorrect negative shortcuts

### DIFF
--- a/packages/preset-applet/src/transformers.ts
+++ b/packages/preset-applet/src/transformers.ts
@@ -22,6 +22,7 @@ export function transformerApplet(options: TransformerAppletOptions = {}): Sourc
   const ESCAPED_UNSUPPORTED_CHARS = _UNSUPPORTED_CHARS.map(char => `\\${char}`)
   const charTestReg = new RegExp(`[${ESCAPED_UNSUPPORTED_CHARS.join('')}]`)
   const charReplaceReg = new RegExp(`[${ESCAPED_UNSUPPORTED_CHARS.join('')}]`, 'g')
+  const negativeReplaceReg = /^-+/
 
   return {
     name: 'transformer-applet',
@@ -34,13 +35,13 @@ export function transformerApplet(options: TransformerAppletOptions = {}): Sourc
       // skip attributify
       const replacements = Array.from(matched).filter(i => charTestReg.test(i))
         .filter(i => !i.includes('='))
-      for (const replace of replacements) {
+      for (let replace of replacements) {
         let replaced = replace.replace(charReplaceReg, '_a_')
         replaced = encodeNonSpaceLatin(replaced)
 
         // delete all - prefix
-        while (replaced.startsWith('-'))
-          replaced = replaced.slice(1)
+        replace = replace.replace(negativeReplaceReg, '')
+        replaced = replaced.replace(negativeReplaceReg, '')
 
         uno.config.shortcuts.push([replaced, replace, { layer }])
         tokens.add(replaced)

--- a/test/preset-applet.test.ts
+++ b/test/preset-applet.test.ts
@@ -1,7 +1,9 @@
-import { createGenerator } from '@unocss/core'
+import { createGenerator, UnocssPluginContext } from '@unocss/core'
 import presetApplet from '@unocss-applet/preset-applet'
 import { describe, expect, it } from 'vitest'
 import { presetExtra } from 'unocss-preset-extra'
+import { transformerApplet } from '@unocss-applet/preset-applet/src/transformers'
+import MagicString from 'magic-string'
 
 const targets = [
   // base
@@ -250,5 +252,30 @@ describe('preset-applet', () => {
     const { css } = await uno.generate(code, { preflights: false })
 
     expect(css).toMatchSnapshot()
+  })
+})
+
+
+const transformer = transformerApplet()
+
+describe('transformer-applet', () => {
+  async function transform(code: string) {
+    const s = new MagicString(code)
+    await transformer.transform(s, '', {
+      tokens: new Set<string>(),
+      uno,
+    } as UnocssPluginContext)
+    return s.toString()
+  }
+
+  it('basic', async () => {
+    const caseAndSnapshotPairs = [
+      ['-ml-1.5 ml-1.5 -mt-2', '-ml-1_a_5 ml-1_a_5 -mt-2'],
+    ]
+
+    for (const [c, snapshot] of caseAndSnapshotPairs) {
+      const result = await transform(c)
+      expect(result).toMatchInlineSnapshot(`"${snapshot}"`)
+    }
   })
 })


### PR DESCRIPTION
当前在使用会被 `transformer-applet` 处理的负值 class 如 `-ml-1.5` 时，该工具类会被转换为 `ml-1_a_5`，同时会把 `ml-1_a_5` 指定为 `-ml-1.5` 的 shortcut ，这会导致后续在使用 `ml-1.5` 时生成的样式为负的 margin 。