### PR TITLE
fix(preset-applet): fix `divide` variant not working

### DIFF
--- a/packages/preset-applet/src/variants.ts
+++ b/packages/preset-applet/src/variants.ts
@@ -13,6 +13,12 @@ export function variantSpaceAndDivide(options: PresetAppletOptions): Variant<The
       if (/space-?([xy])-?(-?.+)$/.test(matcher) || /divide-/.test(matcher)) {
         return {
           matcher,
+          body: (el) => {
+            if (matcher.includes('divide') && el.join(' ').includes('width')) {
+              el.unshift(['border', '0 solid #fff'])
+              return el
+            }
+          },
           selector: (input) => {
             const selectors = betweenElements.map(el => `${input}>${el}+${el}`)
             return selectors.join(',')


### PR DESCRIPTION
由于 `*` 在小程序不起作用

```
* {
  border: 0 solid #fff;
}
```

导致 `divide` 所在元素设置 `border-style` 后左右两边 `border-width` 均被触发，无法正常显示在所在区域，